### PR TITLE
fixed indentation

### DIFF
--- a/upng.h
+++ b/upng.h
@@ -76,6 +76,6 @@ unsigned	upng_get_pixelsize	(const upng_t* upng);
 upng_format	upng_get_format		(const upng_t* upng);
 
 const unsigned char*	upng_get_buffer		(const upng_t* upng);
-unsigned				upng_get_size		(const upng_t* upng);
+unsigned		upng_get_size		(const upng_t* upng);
 
 #endif /*defined(UPNG_H)*/


### PR DESCRIPTION
`upng_get_size` was protruding by two tabs