### PR TITLE
Remove unused variable data.

### DIFF
--- a/upng.c
+++ b/upng.c
@@ -1000,7 +1000,6 @@ upng_error upng_decode(upng_t* upng)
 	 * verify general well-formed-ness */
 	while (chunk < upng->source.buffer + upng->source.size) {
 		unsigned long length;
-		const unsigned char *data;	/*the data in the chunk */
 
 		/* make sure chunk header is not larger than the total compressed */
 		if ((unsigned long)(chunk - upng->source.buffer + 12) > upng->source.size) {
@@ -1020,9 +1019,6 @@ upng_error upng_decode(upng_t* upng)
 			SET_ERROR(upng, UPNG_EMALFORMED);
 			return upng->error;
 		}
-
-		/* get pointer to payload */
-		data = chunk + 8;
 
 		/* parse chunks */
 		if (upng_chunk_type(chunk) == CHUNK_IDAT) {


### PR DESCRIPTION
The purpose of this PR is to remove an unused variable (*data) inside the upng_decode method, which causes a warning during compilation.